### PR TITLE
Add XcodePlugin support

### DIFF
--- a/Plugins/SwiftGenPlugin/Plugin.swift
+++ b/Plugins/SwiftGenPlugin/Plugin.swift
@@ -31,6 +31,33 @@ struct SwiftGenPlugin: BuildToolPlugin {
   }
 }
 
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension SwiftGenPlugin: XcodeBuildToolPlugin {
+  func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
+    let fileManager = FileManager.default
+
+    // Possible paths where there may be a config file (root of package, target dir.)
+    let configurations: [Path] = [context.xcodeProject.directory]
+      .map { $0.appending("swiftgen.yml") }
+      .filter { fileManager.fileExists(atPath: $0.string) }
+
+    // Validate paths list
+    guard validate(configurations: configurations, target: target) else {
+      return []
+    }
+
+    // Clear the SwiftGen plugin's directory (in case of dangling files)
+    fileManager.forceClean(directory: context.pluginWorkDirectory)
+
+    return try configurations.map { configuration in
+      try .swiftgen(using: configuration, context: context, target: target)
+    }
+  }
+}
+#endif
+
 // MARK: - Helpers
 
 private extension SwiftGenPlugin {
@@ -47,6 +74,21 @@ private extension SwiftGenPlugin {
 
     return true
   }
+
+#if canImport(XcodeProjectPlugin)
+  func validate(configurations: [Path], target: XcodeTarget) -> Bool {
+    guard !configurations.isEmpty else {
+      Diagnostics.error("""
+        No SwiftGen configurations found for target \(target.displayName). If you would like to generate sources for this \
+        target include a `swiftgen.yml` in the target's source directory, or include a shared `swiftgen.yml` at the \
+        package's root.
+        """)
+      return false
+    }
+
+    return true
+  }
+#endif
 }
 
 private extension Command {
@@ -69,6 +111,27 @@ private extension Command {
       outputFilesDirectory: context.pluginWorkDirectory
     )
   }
+
+#if canImport(XcodeProjectPlugin)
+  static func swiftgen(using configuration: Path, context: XcodePluginContext, target: XcodeTarget) throws -> Command {
+    .prebuildCommand(
+      displayName: "SwiftGen BuildTool Plugin",
+      executable: try context.tool(named: "swiftgen").path,
+      arguments: [
+        "config",
+        "run",
+        "--verbose",
+        "--config", "\(configuration)"
+      ],
+      environment: [
+        "PROJECT_DIR": context.xcodeProject.directory,
+        "TARGET_NAME": target.displayName,
+        "DERIVED_SOURCES_DIR": context.pluginWorkDirectory
+      ],
+      outputFilesDirectory: context.pluginWorkDirectory
+    )
+  }
+#endif
 }
 
 private extension FileManager {


### PR DESCRIPTION
First thanks for the awesome addition of a build plugin!

This PR is pretty basic and just cope-pastes the existing code with a few modifications to add support for Xcode 14 XcodeProject build plugins.

I tried to keep as much as possible, one thing I'm unsure about is the `PRODUCT_MODULE_NAME` which I couldn't find a counterpart to.