### PR TITLE
Include DERIVED_SOURCES_DIR in command environment

### DIFF
--- a/Plugins/SwiftGen-Generate/Plugin.swift
+++ b/Plugins/SwiftGen-Generate/Plugin.swift
@@ -41,7 +41,8 @@ private extension SwiftGenPlugin {
     [
       "PROJECT_DIR": context.package.directory.string,
       "TARGET_NAME": target?.name ?? "",
-      "PRODUCT_MODULE_NAME": target?.moduleName ?? ""
+      "PRODUCT_MODULE_NAME": target?.moduleName ?? "",
+      "DERIVED_SOURCES_DIR": context.pluginWorkDirectory.string
     ]
   }
 }


### PR DESCRIPTION
Using DERIVED_SOURCES_DIR and running the command plugin using as described in the README results in an error:

> swiftgen: error: File ${DERIVED_SOURCES_DIR} not found.

This change exports the plugin working directory as DERIVED_SOURCES_DIR in the command plugin, the same as in the build tool plugin.