### PR TITLE
Make sure that `swiftgen` can use cache correctly.

### DIFF
--- a/Plugins/SwiftGenPlugin/Plugin.swift
+++ b/Plugins/SwiftGenPlugin/Plugin.swift
@@ -64,11 +64,15 @@ private extension Command {
         "PROJECT_DIR": context.package.directory,
         "TARGET_NAME": target.name,
         "PRODUCT_MODULE_NAME": target.moduleName,
-        "DERIVED_SOURCES_DIR": context.pluginWorkDirectory
+        "DERIVED_SOURCES_DIR": context.outputDirectoryPath
       ],
-      outputFilesDirectory: context.pluginWorkDirectory
+      outputFilesDirectory: context.outputDirectoryPath
     )
   }
+}
+
+private extension PluginContext {
+    var outputDirectoryPath: Path { pluginWorkDirectory.appending(subpath: "output") }
 }
 
 private extension FileManager {


### PR DESCRIPTION
This remove the lines that always emptied `pluginWorkDirectory` before running `swiftgen`. That logic results in `swiftgen` having to re-generate the files on every build, which in turn leads to the compiler seeing new timestamps for the generated files, leading in a lot of re-compilation happening.

I don't fully understand why the lines were there originally, but from what I've read about SPM plugins we should try to use `pluginWorkDirectory` as a cache, which will be the case with this change.
