### PR TITLE
Fix contextual menu command and command-line

### DIFF
--- a/Plugins/SwiftGen-Generate/Plugin.swift
+++ b/Plugins/SwiftGen-Generate/Plugin.swift
@@ -38,7 +38,8 @@ private extension SwiftGenPlugin {
     [
       "PROJECT_DIR": context.package.directory.string,
       "TARGET_NAME": target?.name ?? "",
-      "PRODUCT_MODULE_NAME": target?.moduleName ?? ""
+      "PRODUCT_MODULE_NAME": target?.moduleName ?? "",
+      "DERIVED_SOURCES_DIR": context.pluginWorkDirectory.string
     ]
   }
     

--- a/Plugins/SwiftGen-Generate/Plugin.swift
+++ b/Plugins/SwiftGen-Generate/Plugin.swift
@@ -12,24 +12,21 @@ struct SwiftGenPlugin: CommandPlugin {
   func performCommand(context: PluginContext, arguments: [String]) async throws {
     let swiftgen = try context.tool(named: "swiftgen")
     let fileManager = FileManager.default
+    
+    let configuration = context.package.directory.appending("swiftgen.yml")
+    if fileManager.fileExists(atPath: configuration.string) {
+      try swiftgen.run(configuration, environment: env(context: context))
+    }
 
-    // if user provided arguments, use those
-    if !arguments.isEmpty {
-      try swiftgen.run(arguments: arguments, environment: env(context: context))
-    } else {
-      // otherwise scan for configs
-      let configuration = context.package.directory.appending("swiftgen.yml")
+    // check each target
+    let targetsFromArgs = parseTargets(arguments)
+    let targets = context.package.targets
+      .compactMap { $0 as? SourceModuleTarget }
+      .filter { targetsFromArgs.isEmpty || targetsFromArgs.contains($0.name) }
+    for target in targets {
+      let configuration = target.directory.appending("swiftgen.yml")
       if fileManager.fileExists(atPath: configuration.string) {
-        try swiftgen.run(configuration, environment: env(context: context))
-      }
-
-      // check each target
-      let targets = context.package.targets.compactMap { $0 as? SourceModuleTarget }
-      for target in targets {
-        let configuration = target.directory.appending("swiftgen.yml")
-        if fileManager.fileExists(atPath: configuration.string) {
-          try swiftgen.run(configuration, environment: env(context: context, target: target))
-        }
+        try swiftgen.run(configuration, environment: env(context: context, target: target))
       }
     }
   }
@@ -43,6 +40,17 @@ private extension SwiftGenPlugin {
       "TARGET_NAME": target?.name ?? "",
       "PRODUCT_MODULE_NAME": target?.moduleName ?? ""
     ]
+  }
+    
+  func parseTargets(_ arguments: [String]) -> [String] {
+    var result = [String]()
+    for (i, arg) in arguments.enumerated() where arg == "--target" {
+      let valueIdx = i + 1
+      if valueIdx < arguments.count {
+        result.append(arguments[valueIdx])
+      }
+    }
+    return result
   }
 }
 


### PR DESCRIPTION
Xcode always passes targets as arguments to plugin, thats why a condition `!arguments.isEmpty` is always true, and final command is incorrect. Also have added missing `DERIVED_SOURCES_DIR` environment support.
Fixes #8